### PR TITLE
Create Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# RustBridge Event Code of Conduct
+
+This document is based on [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html).
+
+## Applicability
+
+This Code of Conduct is in effect for any RustBridge event and covers all participants, teachers and attendees.
+
+## Contact
+
+Each event will have an assigned contact person, to be posted in the event registration and at the event.
+
+The Rust Community Team is also available for support at [community@rust-lang.org](mailto:community@rust-lang.org)
+
+## Conduct
+
+* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
+* On IRC and other online communication channels associated with the event, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
+* Please be kind and courteous. There's no need to be mean or rude.
+* Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
+* Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
+* We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term "harassment" as including the definition in the <a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a>; if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don't tolerate behavior that excludes people in socially marginalized groups.
+* Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member or event participant, please reach out to the official event contact immediately. Whoever you are and however you came to a RustBridge event, we care about making this community a safe place for you and we've got your back.
+* Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
+
+## Enforcement and Moderation
+
+* Participants asked to stop any harassing behavior are expected to comply immediately.
+* If a participant engages in behaviour contrary to this Code of Conduct, the RustBridge event organisers have the right to take any actions to keep the event a welcoming environment for all participants. This includes warning the offender or expulsion.
+* The RustBridge event organiser is the final arbiter of what constitutes a violation of this Code of Conduct.
+* Any appeals to decisions should happen following the event through contacting the [Rust Community Team](mailto:community@rust-lang.org).
+
+In the Rust community we strive to go the extra step to look out for each other. Don't just aim to be technically unimpeachable, try to be your best self. In particular, avoid flirting with offensive or sensitive issues, particularly if they're off-topic; this all too often leads to unnecessary fights, hurt feelings, and damaged trust; worse, it can drive people away from the community entirely.
+
+And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could've communicated better — remember that it's your responsibility to make your fellow RustBridge participants comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
+
+## Reporting
+
+If you believe you’re experiencing unacceptable behavior that will not be tolerated as outlined above, please report it to the designated contact for your RustBridge event. If, for any reason, the event contact is not responsive, please contact [community@rust-lang.org](mailto:community@rust-lang.org) (we will take any such reports as time sensitive, though reports to this email address are unlikely to result in a realtime resolution).
+
+Please also report if you observe a potentially dangerous situation, someone in distress, or violations of this Code of Conduct, even if the situation is not happening to you.
+
+If you feel you have been unfairly accused of violating this Code of Conduct, please follow the same reporting process.


### PR DESCRIPTION
Created a Code of Conduct to cover RustBridge Events ... based largely on the Rust Code of Conduct.

I think we will also need a separate document that is a guide for event organizers on using the COC.

Fixes #5 